### PR TITLE
Allow users to clear the chat history with specific phrases

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -51,6 +51,7 @@ export interface IStorage {
   // Chat Messages
   getChatMessages(limit?: number): Promise<ChatMessage[]>;
   createChatMessage(message: InsertChatMessage): Promise<ChatMessage>;
+  clearChatMessages(): Promise<void>;
 
   // Receipt Items
   getReceiptItems(transactionId?: string): Promise<ReceiptItem[]>;
@@ -252,6 +253,10 @@ export class DatabaseStorage implements IStorage {
       .values(insertMessage)
       .returning();
     return message;
+  }
+
+  async clearChatMessages(): Promise<void> {
+    await db.delete(chatMessages);
   }
 
   // Analytics


### PR DESCRIPTION
Implement functionality to clear chat history by detecting specific user phrases. This includes adding a new API endpoint, modifying the client-side logic to handle clear chat messages, and updating the storage layer to delete chat records.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: a7d13748-f313-4535-ae79-106c45ec3553
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/ff0de080-ad38-4ecc-81fa-282ae75e4c96/a7d13748-f313-4535-ae79-106c45ec3553/74lYNve